### PR TITLE
Modification du rôle Modérateur en -> Mentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ channels.forEach( channel => console.log(`- ${channel.name} (${channel.descripti
 
 Merci de respecter le format suivant : `[**TITRE ET/OU EMOJI**] Description - Lien`. Les liens doivent obligatoirement être en relation avec le développement. 
 
-# Modération  
+# Mentors (Modération)  
 
-Tout comportement abusif peut être rapporté aux modérateurs de la communauté. Vous pouvez les mentionner sur Discord avec `@Moderateur`.
+Tout comportement abusif peut être rapporté aux Mentors de la communauté. Vous pouvez les mentionner sur Discord avec `@Mentor`.
 
-Les modérateurs : 
+Les mentors : 
 
 - Fraxken
 - Xavier
 - Purexo
 - Tiyo
 - Antoine N.
+- Nolan 🇨🇭
 

--- a/README.md
+++ b/README.md
@@ -136,4 +136,5 @@ Les mentors :
 - Tiyo
 - Antoine N.
 - Nolan 🇨🇭
+- Romain Lanz
 


### PR DESCRIPTION
Mise à jour des rôles de modération de la communauté.

(**Attention**: Ceci est une évolution du Code de conduite, elle est donc soumise au délai réglementaire imposé par le CDG).

Etat des changements sur le Discord (et explication) : 

**Administrateur** devient **Fondateur**.
**Modérateur** devient **Mentor**.

L'objectif de cette mise à jour être d'apporter un sens beaucoup plus honorifique aux titres (La modération est de toute manière un devoir communautaire). Les mentors seront là pour aider et accompagner les nouveaux membres de la communauté.

Et nous pourrons agrandir l'équipe des mentors accordement à l'évolution de la communauté beaucoup plus simplement !

**Les (anciens) modérateurs se voient retirer les droits suivants** : 
- Création et édition des salons
- Edition de la liste d'emoji. 

Ses deux LCA sont de toute manière soumit au CDG (Code de contribution).

Les mentors ont toujours les droits suivants sur le Discord : 
- Gestion (suppression) des messages.
- Gestion des rôles

La gestion des rôles sera éventuellement à remettre en cause plus tard si le Bot de la communauté est hébergé 24h/24. 

Cordialement,
L'équipe de Modération !