### PR TITLE
chore: update channels description

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,19 @@ for (const [name, description] of channels) {
 - `#tweets` - Salon privé où le Bot publie fréquemment les tweets les plus intéressants sur Node.js et ECMAScript.
 
 #### DEVELOPPEMENT
+- `#debutant` - Salon dédié à toutes questions de débutant
 - `#ecmascript` - Tout ce qui est en liaison avec l'écosystème ECMAScript, par exemple : TypeScript, Babel, etc.
+- `#front` - HTML & CSS, UI/UX Designer, WEBGL, Framework front, VanillaJS, JQuery, etc.
 - `#nodejs` - Pour parler de tout ce qui concerne Node.js
 - `#design` - Salon permettant de partager des créations graphiques.
-- `#front` - HTML & CSS, UI/UX Designer, WEBGL, Framework front, VanillaJS, JQuery, etc.
 - `#native` - Tout ce qui concerne l'implémentation de packages natif sur Node.js (N-API, NaN et Neon).
 - `#security` - Tout ce qui est lien avec la sécurité d'applications web, les bonnes pratiques d'authentification, etc.
 - `#autres` - Tout autres sujets qui concernent le développement.
 
 #### SYSTEME ET DATABASES
+- `#database` - Tout ce qui concerne des problèmes liés à une SGBD.
 - `#linux` - Tout les systèmes Linux (UNIX).
 - `#docker` - Tout ce qui concerne Docker. (Déploiement, configuration etc..).
-- `#database` - Tout ce qui concerne des problèmes liés à une SGBD.
 - `#autres` - Tout autres problèmes en liaison avec le système.
 
 #### AUTRES
@@ -139,7 +140,7 @@ for (const [name, description] of channels) {
 #### EVENEMENTS
 - `#nodeschool` - Discussions autour de la NodeSchool.
 - `#weektalk` - Infos sur les prochains [weektalks](https://github.com/ES-Community/weektalk).
-- `#insomni-hack` - Discussions au sujet d'insomni-hack.
+- `#insomni-hack` - Discussions au sujet de [l'insomni-hack](https://insomnihack.ch).
 - `#ludum-dare` - Discussions au sujet de [Ludum Dare](https://ldjam.com/events/ludum-dare/rules).
 
 #### FORMATS


### PR DESCRIPTION
- Ajout du channel `#debutant` manquant
- Changement de l'ordre des channels par rapport à l'ordre réel du Discord
- Ajout d'un lien concernant l'Insomni'hack