### PR TITLE
Ajout d'un canal #démocratie

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ for (const [name, description] of channels) {
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 - `#tweets` - Salon privé où le Bot publie fréquemment les tweets les plus intéressants sur Node.js et ECMAScript.
+- `#démocratie` - Salon en lecture seule alimenté par webhooks github, affiche les nouvelles issues et pull-request du code of conduct
 
 #### DEVELOPPEMENT
 - `#debutant` - Salon dédié à toutes questions de débutant


### PR DESCRIPTION
proposition d'ajout d'un canal démocratie pour notifier de ce qui ce passe sur le code of conduct.

Actuellement peu de personnes en dehors des mentors donne leurs avis sur les issues et PR. je suppose que c'est simplement car ils ne suivent pas ce repo, ou ce noie dans d'autres notifications.

Le nom est à débattre mais je trouvais l'appellation sympa