### PR TITLE
Nomination de Koko pour le rôle de mentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,4 @@ Les mentors :
 - Tiyo
 - Romain Lanz
 - Targos
+- Koko


### PR DESCRIPTION
Avec son accord, je propose Koko au rôle de mentor.
Ca ne fait pas très longtemps qu'il est avec nous (une année en décembre), mais il s'est très tôt démarqué par son activité, par sa communication adéquate et par son volontariat à aider les membres quand il le pouvait. 