### PR TITLE
Ajout du canal #live

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ES-Community est une communauté ECMAScript francophone créée fin 2015. Notre 
     - [Evenements](#evenements)
   - [Formats](#formats)
     - [#liens](#liens)
+    - [#lives](#lives)
     - [#jobs](#jobs)
     - [#projets](#projets)
 - [Administrateurs](#administrateurs)
@@ -116,7 +117,7 @@ for (const [name, description] of channels) {
 - `#presentation` - Présentations des membres de la communauté
 - `#blabla` - Salon libre
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
-- `#live` - Salon d'annonce de stream de nos membres.
+- `#lives` - Salon d'annonce de stream de nos membres.
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 - `#tweets` - Salon privé où le Bot publie fréquemment les tweets les plus intéressants sur Node.js et ECMAScript.
 
@@ -161,6 +162,17 @@ Les liens doivent obligatoirement être en relation avec le développement.
 `[**TITRE et/ou ÉMOJI**] Description - Lien`
 
 ![Salon liens](https://user-images.githubusercontent.com/2799010/45076365-4322f380-b0ea-11e8-9d98-3fb9913b0f20.png)
+
+### #lives
+Les lives doivent obligatoirement être en relation avec le développement. 
+
+```md
+Description courte (ce que vous allez faire, stack utilisée, etc.)
+
+Date (et heure) du live
+
+Lien vers votre chaine
+```
 
 ### #jobs
 ```md

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ for (const [name, description] of channels) {
 - `#presentation` - Présentations des membres de la communauté
 - `#blabla` - Salon libre
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
+- `#live` - Salon d'annonce de stream de nos membres.
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 - `#tweets` - Salon privé où le Bot publie fréquemment les tweets les plus intéressants sur Node.js et ECMAScript.
-- `#live` - Salon d'annonce de stream de nos membres (en rapport avec la programmation, ou pas !)
 
 ### Développement
 - `#debutant` - Salon dédié à toutes questions de débutant

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ for (const [name, description] of channels) {
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 - `#tweets` - Salon privé où le Bot publie fréquemment les tweets les plus intéressants sur Node.js et ECMAScript.
+- `#live` - Salon d'annonce de stream de nos membres (en rapport avec la programation, ou pas !)
 
 ### Développement
 - `#debutant` - Salon dédié à toutes questions de débutant

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ for (const [name, description] of channels) {
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 - `#tweets` - Salon privé où le Bot publie fréquemment les tweets les plus intéressants sur Node.js et ECMAScript.
-- `#live` - Salon d'annonce de stream de nos membres (en rapport avec la programation, ou pas !)
+- `#live` - Salon d'annonce de stream de nos membres (en rapport avec la programmation, ou pas !)
 
 ### Développement
 - `#debutant` - Salon dédié à toutes questions de débutant


### PR DESCRIPTION
Hello ! 👋🏻 

Je propose d'ajouter le canal #live dans notre Discord.

Celui-ci permettrai d'annoncer des lives futures ou en cours de nos membres.
À voir si on autorise à pub un live qui ne concerne pas le développement.

Le concept est de garder le canal propre.
C'est-à-dire qu'on peut poster pour annoncer un live futur, ou le fait d'être en live, mais une fois celui-ci passé, il faut supprimer le message d'annonce (ou de live).

C'est comme cela que le canal fonctionne sur le Discord de Grafikart, et je pense que c'est une bonne méthode.

![image](https://user-images.githubusercontent.com/2793951/147782088-9514f20f-236c-4267-a4be-50f8d9e97264.png)