### PR TITLE
Retrait de Tiyo comme Mentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ Les mentors :
 - Fraxken
 - Xavier
 - Purexo
-- Tiyo
 - Romain Lanz
 - Targos
 - Koko


### PR DESCRIPTION
Hello !

Il est inactif depuis juillet 2021 et on a plus trop de nouvelles malgré quelques pings. (à moins que quelqu'un en ait eu que je n'aie pas eu ?)