### PR TITLE
feat: add #news channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ for (const [name, description] of channels) {
 - `#blabla` - Salon libre
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
 - `#lives` - Salon d'annonce de stream de nos membres.
-- `#news` - Salon de suivis des nouvelles tech.
+- `#news` - Salon de suivi des nouvelles tech.
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 
 ### Développement
@@ -210,17 +210,17 @@ Description du projet
 
 ## #news
 
-Ce canal est en lecture seule, y seront retransmis les nouvelles de
+Ce canal est en lecture seule, y seront retransmises les nouvelles de
 
 - Typescript, TypeScript Community #updates (Discord), annonces des MaJs de Typescript
 - Node.js, Webhook github sur les releases
 
-La communauté peut proposer la mise à jours de cette liste via une PR. Peuvent être envisagé comme source de communication simple :
+La communauté peut proposer la mise à jour de cette liste via une PR. Peuvent être envisagées comme source de communication simple :
 
 - un canal d'annonce d'un serveur Discord
 - un webhook
 
-En l'absence de ces moyens, Feed RSS et scrapping peuvent être ajouté via le [Bot](#Bot)
+En l'absence de ces moyens, Feed RSS et scrapping peuvent être ajoutés via le [Bot](#Bot)
 
 ## Threads
 Maintenant que Discord autorise la création de fils de discussion (threads), vous êtes libre de les utiliser.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ Description du projet
 Ce canal est en lecture seule, y seront retransmises les nouvelles de
 
 - Typescript, TypeScript Community #updates (Discord), annonces des MaJs de Typescript
-- Node.js, Webhook github sur les releases
+- Node.js, via feed atom (bot), annonces des releases de Node.js
+- AdonisJS, AdonisJS Framework #📢-announces (Discord), annonces des MaJs de Adonis
 
 La communauté peut proposer la mise à jour de cette liste via une PR. Peuvent être envisagées comme source de communication simple :
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ ES-Community est une communauté ECMAScript francophone créée fin 2015. Notre 
     - [#lives](#lives)
     - [#jobs](#jobs)
     - [#projets](#projets)
+  - [#news](#news)
   - [Threads](#threads)
 - [Bot](#bot)
 - [Politique d'archivage](#politique-d-archivage)
@@ -121,6 +122,7 @@ for (const [name, description] of channels) {
 - `#blabla` - Salon libre
 - `#liens` - Ce salon vous permet d'envoyer des liens vers des projets/drafts intéressants (Obligatoirement en lien avec le groupe).
 - `#lives` - Salon d'annonce de stream de nos membres.
+- `#news` - Salon de suivis des nouvelles tech.
 - `#jobs` - Salon permettant de partager des offres d'emploi au reste de la communauté
 
 ### Développement
@@ -205,6 +207,20 @@ Description du projet
 ```
 
 ![Salon projets](https://user-images.githubusercontent.com/2799010/45077282-05739a00-b0ed-11e8-9574-43152eb60e22.png)
+
+## #news
+
+Ce canal est en lecture seule, y seront retransmis les nouvelles de
+
+- Typescript, TypeScript Community #updates (Discord), annonces des MaJs de Typescript
+- Node.js, Websocket github sur les releases
+
+La communauté peut proposer la mise à jours de cette liste via une PR. Peuvent être envisagé comme source de communication simple :
+
+- un canal d'annonce d'un serveur Discord
+- un websocket
+
+En l'absence de ces moyens, Feed RSS et scrapping peuvent être ajouté via le [Bot](#Bot)
 
 ## Threads
 Maintenant que Discord autorise la création de fils de discussion (threads), vous êtes libre de les utiliser.

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ Description du projet
 Ce canal est en lecture seule, y seront retransmis les nouvelles de
 
 - Typescript, TypeScript Community #updates (Discord), annonces des MaJs de Typescript
-- Node.js, Websocket github sur les releases
+- Node.js, Webhook github sur les releases
 
 La communauté peut proposer la mise à jours de cette liste via une PR. Peuvent être envisagé comme source de communication simple :
 
 - un canal d'annonce d'un serveur Discord
-- un websocket
+- un webhook
 
 En l'absence de ces moyens, Feed RSS et scrapping peuvent être ajouté via le [Bot](#Bot)
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Ce canal est en lecture seule, y seront retransmises les nouvelles de
 - Typescript, TypeScript Community #updates (Discord), annonces des MaJs de Typescript
 - Node.js, via feed atom (bot), annonces des releases de Node.js
 - AdonisJS, AdonisJS Framework #📢-announces (Discord), annonces des MaJs de Adonis
+- Tailwind CSS, Tailwind CSS #announcements (Discord), annonces des MaJs de Tailwind CSS
 
 La communauté peut proposer la mise à jour de cette liste via une PR. Peuvent être envisagées comme source de communication simple :
 


### PR DESCRIPTION
Bonjour,

Réflexion faites est que des annonces automatiques ont été mis en place en dehors d'une normalisation dans le CoC.

Il est temps de normaliser et officialiser cela, tout en faisant le ménage. Force est de constater que les news de Next et Nuxt sont peu pertinente. Ils utilisent leur canal d'annonces comme un outil promotionnel et non comme un flux de veille.

Les annonces avaient été dispatchés dans différents canaux en fonction du sujet, l'idée maintenant est de faire un canal dédié `#news` pour éviter mélanger les annonces avec les discussions.

News à mettre en place pour cette v1 : Typescript (déplacer les annonces dans le nouveau canal), Node.js (release, mettre en place via webhook).
Les autres annonces mises en places seront retirés (Next.js et Nuxt.js. compléter la liste si items manquants) 