### PR TITLE
chore: rename weektalk to wetalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ for (const [name, description] of channels) {
 
 ### Evenements
 - `#meetup` - Discussions autour des différents meetup.
-- `#weektalk` - Infos sur les prochains [weektalks](https://github.com/ES-Community/weektalk).
+- `#wetalk` - Infos sur les prochains [wetalks](https://github.com/ES-Community/wetalk).
 - `#insomni-hack` - Discussions au sujet de [l'insomni-hack](https://insomnihack.ch).
 - `#ludum-dare` - Discussions au sujet de [Ludum Dare](https://ldjam.com/events/ludum-dare/rules).
 - `#advent-of-code` - Discussions au sujet de [l'advent of code](https://adventofcode.com/)


### PR DESCRIPTION
Hello ! 👋🏻 

Suite à https://github.com/ES-Community/wetalk/issues/4, je propose le changement de nom dans le CoC.

A savoir que tout le monde a déjà voté sur l'issue, j'ai donc pris de l'avant et déjà renommer le repository.